### PR TITLE
Application configuration fixes

### DIFF
--- a/src/main/java/org/qubership/integration/platform/engine/configuration/KubeOperatorConfiguration.java
+++ b/src/main/java/org/qubership/integration/platform/engine/configuration/KubeOperatorConfiguration.java
@@ -49,7 +49,7 @@ public class KubeOperatorConfiguration {
             @Value("${kubernetes.cluster.namespace}") String namespace,
             @Value("${kubernetes.service-account.token-file-path}") String tokenFilePath,
             @Value("${kubernetes.service-account.cert}") String cert,
-            @Value("${kubernetes.cluster.token}") Optional<String> devToken) {
+            @Value("${kubernetes.cluster.token:#{null}}") Optional<String> devToken) {
 
         this.uri = uri;
         this.namespace = namespace;

--- a/src/main/java/org/qubership/integration/platform/engine/configuration/SessionsMetricsServiceConfiguration.java
+++ b/src/main/java/org/qubership/integration/platform/engine/configuration/SessionsMetricsServiceConfiguration.java
@@ -20,6 +20,7 @@ package org.qubership.integration.platform.engine.configuration;
 import org.qubership.integration.platform.engine.persistence.shared.repository.CheckpointRepository;
 import org.qubership.integration.platform.engine.service.debugger.metrics.MetricsStore;
 import org.qubership.integration.platform.engine.service.debugger.metrics.SessionsMetricsService;
+import org.qubership.integration.platform.engine.opensearch.OpenSearchClientSupplier;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -34,10 +35,9 @@ public class SessionsMetricsServiceConfiguration {
     @Bean
     @ConditionalOnProperty(value = "qip.metrics.enabled", havingValue = "true")
     public SessionsMetricsService getMetricsService(MetricsStore metricsStore,
-                                                    OpenSearchClient opensearchClient,
-                                                    Function<String, String> openSearchEntityNameNormalizer,
+                                                    OpenSearchClientSupplier openSearchClientSupplier,
                                                     CheckpointRepository checkpointRepository) {
 
-        return new SessionsMetricsService(metricsStore, opensearchClient, openSearchEntityNameNormalizer, checkpointRepository);
+        return new SessionsMetricsService(metricsStore, openSearchClientSupplier, checkpointRepository);
     }
 }

--- a/src/main/java/org/qubership/integration/platform/engine/configuration/datasource/FlywayInitializer.java
+++ b/src/main/java/org/qubership/integration/platform/engine/configuration/datasource/FlywayInitializer.java
@@ -24,9 +24,11 @@ import org.flywaydb.core.api.configuration.ClassicConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-@Configuration
+@AutoConfiguration
+@ConditionalOnProperty(name = "qip.flyway-initializer.enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnBean({PersistenceCheckpointAutoConfiguration.class, PersistenceQuartzAutoConfiguration.class})
 @EnableConfigurationProperties(FlywayConfigProperties.class)
 public class FlywayInitializer {

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -7,3 +7,4 @@ org.qubership.integration.platform.engine.configuration.SwaggerAutoConfiguration
 org.qubership.integration.platform.engine.configuration.ApplicationAutoConfiguration
 org.qubership.integration.platform.engine.configuration.web.WebAutoConfiguration
 org.qubership.integration.platform.engine.configuration.DeploymentReadinessAutoConfiguration
+org.qubership.integration.platform.engine.configuration.datasource.FlywayInitializer


### PR DESCRIPTION
* Fixed Camel Quartz configuration
* Fixed default value of k8s development token
* FlywayInitializer moved from configuration to auto-configuration
* Introduced property qip.flyway-initializer.enabled that controls FlywayInitializer presence in application context
* Fixed sessions metrics service