### PR TITLE
fix: #196 Removed use of date_add function in idempotency query

### DIFF
--- a/src/main/java/org/qubership/integration/platform/engine/persistence/shared/repository/IdempotencyRecordRepository.java
+++ b/src/main/java/org/qubership/integration/platform/engine/persistence/shared/repository/IdempotencyRecordRepository.java
@@ -31,13 +31,13 @@ public interface IdempotencyRecordRepository extends JpaRepository<IdempotencyRe
                     :key,
                     :data ::json,
                     now(),
-                    date_add(now(), make_interval(secs => :ttl))
+                    now() + make_interval(secs => :ttl)
                 )
                 on conflict (key) do update
                     set
                         data = :data ::json,
                         created_at = now(),
-                        expires_at = date_add(now(), make_interval(secs => :ttl))
+                        expires_at = now() + make_interval(secs => :ttl)
                     where
                         r.expires_at < now()
             """


### PR DESCRIPTION
The date_add function is not supported for PostgreSQL versions 15 and later.

Close #196 