### PR TITLE
feat: renames sendEmptyQueryParams to skipEmptyQueryParams in engine …

### DIFF
--- a/src/main/java/org/qubership/integration/platform/engine/camel/processors/QueryParameterFilterProcessor.java
+++ b/src/main/java/org/qubership/integration/platform/engine/camel/processors/QueryParameterFilterProcessor.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class QueryParameterFilterProcessor implements Processor {
 
-    private static final String SERVICE_CALL_SEND_EMPTY_QUERY_PARAMS = "serviceCallSendEmptyQueryParams";
+    private static final String SERVICE_CALL_SKIP_EMPTY_QUERY_PARAMS = "serviceCallSkipEmptyQueryParams";
     private static final String SERVICE_CALL_QUERY_PARAMETER_PREFIX  = "serviceCallQueryParameter_";
 
     @Override
@@ -41,10 +41,10 @@ public class QueryParameterFilterProcessor implements Processor {
             return;
         }
 
-        Object sendEmptyParamsProperty = exchange.getProperty(SERVICE_CALL_SEND_EMPTY_QUERY_PARAMS);
-        boolean sendEmptyParams = sendEmptyParamsProperty != null && Boolean.parseBoolean(String.valueOf(sendEmptyParamsProperty));
+        Object skipEmptyParamsProperty = exchange.getProperty(SERVICE_CALL_SKIP_EMPTY_QUERY_PARAMS);
+        boolean shouldSkipEmptyParams = skipEmptyParamsProperty != null && Boolean.parseBoolean(String.valueOf(skipEmptyParamsProperty));
 
-        if (!sendEmptyParams) {
+        if (shouldSkipEmptyParams) {
             String finalUri = generateFilteredQueryParams(uri, exchange);
             message.setHeader(CamelConstants.Headers.HTTP_URI, finalUri);
         }

--- a/src/main/java/org/qubership/integration/platform/engine/model/constants/CamelConstants.java
+++ b/src/main/java/org/qubership/integration/platform/engine/model/constants/CamelConstants.java
@@ -161,7 +161,7 @@ public final class CamelConstants {
 
         public static final String SERVICE_CALL_RETRY_COUNT = "retryCount";
         public static final String SERVICE_CALL_RETRY_DELAY = "retryDelay";
-        public static final String SEND_EMPTY_QUERY_PARAMS = "sendEmptyQueryParams";
+        public static final String SKIP_EMPTY_QUERY_PARAMS = "integrationOperationSkipEmptyQueryParameters";
 
         public static final int SERVICE_CALL_DEFAULT_RETRY_DELAY = 5000;
 


### PR DESCRIPTION
…and changes logic accordingly

- Updates property value to integrationOperationSkipEmptyQueryParameters
- Renames SERVICE_CALL_SEND_EMPTY_QUERY_PARAMS to SERVICE_CALL_SKIP_EMPTY_QUERY_PARAMS
- Rename ssendEmptyParams to shouldSkipEmptyParams for clarity
- Updates filtering condition from !sendEmptyParams to shouldSkipEmptyParams