### PR TITLE
fix: fixed memory leak in pubsub consumer

### DIFF
--- a/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomCamelMessageReceiver.java
+++ b/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomCamelMessageReceiver.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024-2026 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.camel.components.pubsub;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.common.base.Strings;
+import com.google.pubsub.v1.PubsubMessage;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.component.google.pubsub.GooglePubsubConstants;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
+import org.apache.camel.component.google.pubsub.consumer.AcknowledgeAsync;
+import org.apache.camel.component.google.pubsub.consumer.AcknowledgeCompletion;
+import org.apache.camel.component.google.pubsub.consumer.GooglePubsubAcknowledge;
+import org.apache.camel.support.DefaultConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CustomCamelMessageReceiver implements MessageReceiver {
+
+    private final Logger localLog;
+    private final DefaultConsumer consumer;
+    private final GooglePubsubEndpoint endpoint;
+    private final Processor processor;
+
+    public CustomCamelMessageReceiver(DefaultConsumer consumer, GooglePubsubEndpoint endpoint, Processor processor) {
+        this.consumer = consumer;
+        this.endpoint = endpoint;
+        this.processor = processor;
+        String loggerId = endpoint.getLoggerId();
+        if (Strings.isNullOrEmpty(loggerId)) {
+            loggerId = this.getClass().getName();
+        }
+        localLog = LoggerFactory.getLogger(loggerId);
+    }
+
+    @Override
+    public void receiveMessage(PubsubMessage pubsubMessage, AckReplyConsumer ackReplyConsumer) {
+        if (localLog.isTraceEnabled()) {
+            localLog.trace("Received message ID : {}", pubsubMessage.getMessageId());
+        }
+
+        Exchange exchange = consumer.createExchange(true);
+        exchange.getIn().setBody(pubsubMessage.getData().toByteArray());
+
+        exchange.getIn().setHeader(GooglePubsubConstants.MESSAGE_ID, pubsubMessage.getMessageId());
+        exchange.getIn().setHeader(GooglePubsubConstants.PUBLISH_TIME, pubsubMessage.getPublishTime());
+        exchange.getIn().setHeader(GooglePubsubConstants.ATTRIBUTES, pubsubMessage.getAttributesMap());
+
+        GooglePubsubAcknowledge acknowledge = new AcknowledgeAsync(ackReplyConsumer);
+        if (endpoint.getAckMode() != GooglePubsubConstants.AckMode.NONE) {
+            exchange.getExchangeExtension().addOnCompletion(new AcknowledgeCompletion(acknowledge));
+        } else {
+            exchange.getIn().setHeader(GooglePubsubConstants.GOOGLE_PUBSUB_ACKNOWLEDGE, acknowledge);
+        }
+
+        try {
+            processor.process(exchange);
+        } catch (Exception e) {
+            consumer.getExceptionHandler().handleException(e);
+        }
+    }
+
+}

--- a/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomGooglePubSubComponent.java
+++ b/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomGooglePubSubComponent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024-2026 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.camel.components.pubsub;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.component.google.pubsub.GooglePubsubComponent;
+import org.apache.camel.spi.annotations.Component;
+
+import java.util.Map;
+
+/*
+
+When a subscription is no longer exist starting a subscriber throws an exception.
+That causes a continuous creation of a new subscriber and addition it to a subscriber list in a loop.
+The consumed memory grows until it reaches its limits.
+
+The fix requires changes in the private methods of GooglePubSubConsumer class.
+So unless this issue is fixed in Apache Camel, we have to have a local copy of CamelGooglePubSub component with the issue fixed.
+
+Here is the link to an issue in Camel Issue Tracker:
+
+https://issues.apache.org/jira/browse/CAMEL-22898
+
+ */
+
+@Component("google-pubsub")
+public class CustomGooglePubSubComponent extends GooglePubsubComponent {
+    @Override
+    protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
+        String[] parts = remaining.split(":");
+
+        if (parts.length < 2) {
+            throw new IllegalArgumentException(
+                    "Google PubSub Endpoint format \"projectId:destinationName[:subscriptionName]\"");
+        }
+
+        CustomGooglePubSubEndpoint pubsubEndpoint = new CustomGooglePubSubEndpoint(uri, this);
+        pubsubEndpoint.setProjectId(parts[0]);
+        pubsubEndpoint.setDestinationName(parts[1]);
+        pubsubEndpoint.setServiceAccountKey(getServiceAccountKey());
+        pubsubEndpoint.setAuthenticate(isAuthenticate());
+
+        setProperties(pubsubEndpoint, parameters);
+
+        return pubsubEndpoint;
+    }
+}

--- a/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomGooglePubSubConsumer.java
+++ b/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomGooglePubSubConsumer.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2024-2026 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.camel.components.pubsub;
+
+import com.google.api.core.AbstractApiService;
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.common.base.Strings;
+import com.google.pubsub.v1.*;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.component.google.pubsub.GooglePubsubConstants;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
+import org.apache.camel.component.google.pubsub.consumer.AcknowledgeCompletion;
+import org.apache.camel.component.google.pubsub.consumer.AcknowledgeSync;
+import org.apache.camel.component.google.pubsub.consumer.GooglePubsubAcknowledge;
+import org.apache.camel.support.DefaultConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import static java.util.Objects.nonNull;
+
+public class CustomGooglePubSubConsumer extends DefaultConsumer {
+
+    private final Logger localLog;
+
+    private final GooglePubsubEndpoint endpoint;
+    private final Processor processor;
+    private ExecutorService executor;
+    private final List<Subscriber> subscribers;
+    private final Set<ApiFuture<PullResponse>> pendingSynchronousPullResponses;
+
+    CustomGooglePubSubConsumer(GooglePubsubEndpoint endpoint, Processor processor) {
+        super(endpoint, processor);
+        this.endpoint = endpoint;
+        this.processor = processor;
+        this.subscribers = Collections.synchronizedList(new LinkedList<>());
+        this.pendingSynchronousPullResponses = Collections.synchronizedSet(new HashSet<>());
+        String loggerId = endpoint.getLoggerId();
+
+        if (Strings.isNullOrEmpty(loggerId)) {
+            loggerId = this.getClass().getName();
+        }
+
+        localLog = LoggerFactory.getLogger(loggerId);
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+        localLog.info("Starting Google PubSub consumer for {}/{}", endpoint.getProjectId(), endpoint.getDestinationName());
+        executor = endpoint.createExecutor();
+        for (int i = 0; i < endpoint.getConcurrentConsumers(); i++) {
+            executor.submit(new SubscriberWrapper());
+        }
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        localLog.info("Stopping Google PubSub consumer for {}/{}", endpoint.getProjectId(), endpoint.getDestinationName());
+
+        synchronized (subscribers) {
+            if (!subscribers.isEmpty()) {
+                localLog.info("Stopping subscribers for {}/{}", endpoint.getProjectId(), endpoint.getDestinationName());
+                subscribers.forEach(AbstractApiService::stopAsync);
+            }
+        }
+
+        safeCancelSynchronousPullResponses();
+
+        if (executor != null) {
+            if (getEndpoint() != null && getEndpoint().getCamelContext() != null) {
+                getEndpoint().getCamelContext().getExecutorServiceManager().shutdownGraceful(executor);
+            } else {
+                executor.shutdownNow();
+            }
+        }
+        executor = null;
+    }
+
+    private void safeCancelSynchronousPullResponses() {
+        synchronized (pendingSynchronousPullResponses) {
+            for (ApiFuture<PullResponse> pullResponseApiFuture : pendingSynchronousPullResponses) {
+                try {
+                    pullResponseApiFuture.cancel(true);
+                } catch (Exception e) {
+                    localLog.warn("Exception while cancelling pending synchronous pull response", e);
+                }
+            }
+            pendingSynchronousPullResponses.clear();
+        }
+    }
+
+    private class SubscriberWrapper implements Runnable {
+
+        private final String subscriptionName;
+
+        SubscriberWrapper() {
+            subscriptionName = ProjectSubscriptionName.format(endpoint.getProjectId(), endpoint.getDestinationName());
+        }
+
+        @Override
+        public void run() {
+            try {
+                if (localLog.isDebugEnabled()) {
+                    localLog.debug("Subscribing to {}", subscriptionName);
+                }
+
+                if (endpoint.isSynchronousPull()) {
+                    synchronousPull(subscriptionName);
+                } else {
+                    asynchronousPull(subscriptionName);
+                }
+
+                localLog.debug("Exit run for subscription {}", subscriptionName);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                localLog.error("Failure getting messages from PubSub", e);
+            } catch (Exception e) {
+                localLog.error("Failure getting messages from PubSub", e);
+            }
+        }
+
+        private void asynchronousPull(String subscriptionName) throws IOException {
+            while (isRunAllowed() && !isSuspendingOrSuspended()) {
+                MessageReceiver messageReceiver = new CustomCamelMessageReceiver(CustomGooglePubSubConsumer.this, endpoint, processor);
+
+                Subscriber subscriber = null;
+                try {
+                    subscriber = endpoint.getComponent().getSubscriber(subscriptionName, messageReceiver, endpoint);
+                    subscribers.add(subscriber);
+                    subscriber.startAsync().awaitRunning();
+                    subscriber.awaitTerminated();
+                } catch (Exception e) {
+                    localLog.error("Failure getting messages from PubSub", e);
+                } finally {
+                    localLog.debug("Stopping async subscriber {}", subscriptionName);
+                    if (nonNull(subscriber)) {
+                        subscriber.stopAsync();
+                        subscribers.remove(subscriber);
+                    }
+                }
+            }
+        }
+
+        private void synchronousPull(String subscriptionName) throws ExecutionException, InterruptedException {
+            while (isRunAllowed() && !isSuspendingOrSuspended()) {
+                ApiFuture<PullResponse> synchronousPullResponseFuture = null;
+                try (SubscriberStub subscriber = endpoint.getComponent().getSubscriberStub(endpoint)) {
+
+                    PullRequest pullRequest = PullRequest.newBuilder()
+                            .setMaxMessages(endpoint.getMaxMessagesPerPoll())
+                            .setReturnImmediately(false)
+                            .setSubscription(subscriptionName)
+                            .build();
+
+                    synchronousPullResponseFuture = subscriber.pullCallable().futureCall(pullRequest);
+                    pendingSynchronousPullResponses.add(synchronousPullResponseFuture);
+                    PullResponse pullResponse = synchronousPullResponseFuture.get();
+                    for (ReceivedMessage message : pullResponse.getReceivedMessagesList()) {
+                        PubsubMessage pubsubMessage = message.getMessage();
+                        Exchange exchange = createExchange(true);
+                        exchange.getIn().setBody(pubsubMessage.getData().toByteArray());
+
+                        exchange.getIn().setHeader(GooglePubsubConstants.ACK_ID, message.getAckId());
+                        exchange.getIn().setHeader(GooglePubsubConstants.MESSAGE_ID, pubsubMessage.getMessageId());
+                        exchange.getIn().setHeader(GooglePubsubConstants.PUBLISH_TIME, pubsubMessage.getPublishTime());
+                        exchange.getIn().setHeader(GooglePubsubConstants.ATTRIBUTES, pubsubMessage.getAttributesMap());
+
+                        //existing subscriber can not be propagated, because it will be closed at the end of this block
+                        //subscriber will be created at the moment of use
+                        // (see  https://issues.apache.org/jira/browse/CAMEL-18447)
+                        GooglePubsubAcknowledge acknowledge = new AcknowledgeSync(
+                                () -> endpoint.getComponent().getSubscriberStub(endpoint), subscriptionName);
+
+                        if (endpoint.getAckMode() != GooglePubsubConstants.AckMode.NONE) {
+                            exchange.getExchangeExtension().addOnCompletion(new AcknowledgeCompletion(acknowledge));
+                        } else {
+                            exchange.getIn().setHeader(GooglePubsubConstants.GOOGLE_PUBSUB_ACKNOWLEDGE, acknowledge);
+                        }
+
+                        try {
+                            processor.process(exchange);
+                        } catch (Exception e) {
+                            getExceptionHandler().handleException(e);
+                        }
+                    }
+                } catch (CancellationException e) {
+                    localLog.debug("PubSub synchronous pull request cancelled", e);
+                } catch (IOException e) {
+                    localLog.error("I/O exception while getting messages from PubSub. Reconnecting.", e);
+                } catch (ExecutionException e) {
+                    if (e.getCause() instanceof ApiException && ((ApiException) (e.getCause())).isRetryable()) {
+                        localLog.error("Retryable API exception in getting messages from PubSub", e.getCause());
+                    } else {
+                        throw e;
+                    }
+                } finally {
+                    if (synchronousPullResponseFuture != null) {
+                        pendingSynchronousPullResponses.remove(synchronousPullResponseFuture);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomGooglePubSubEndpoint.java
+++ b/src/main/java/org/qubership/integration/platform/engine/camel/components/pubsub/CustomGooglePubSubEndpoint.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-2026 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.camel.components.pubsub;
+
+import org.apache.camel.*;
+import org.apache.camel.component.google.pubsub.GooglePubsubConstants;
+import org.apache.camel.component.google.pubsub.GooglePubsubEndpoint;
+import org.apache.camel.spi.UriEndpoint;
+
+@UriEndpoint(firstVersion = "2.19.0", scheme = "google-pubsub", title = "Google Pubsub",
+        syntax = "google-pubsub:projectId:destinationName", category = { Category.CLOUD, Category.MESSAGING },
+        headersClass = GooglePubsubConstants.class)
+public class CustomGooglePubSubEndpoint extends GooglePubsubEndpoint {
+    public CustomGooglePubSubEndpoint(String uri, Component component) {
+        super(uri, component);
+    }
+
+    @Override
+    public Consumer createConsumer(Processor processor) throws Exception {
+        afterPropertiesSet();
+        setExchangePattern(ExchangePattern.InOnly);
+        CustomGooglePubSubConsumer consumer = new CustomGooglePubSubConsumer(this, processor);
+        configureConsumer(consumer);
+        return consumer;
+    }
+}

--- a/src/main/java/org/qubership/integration/platform/engine/configuration/camel/CamelPubSubConfiguration.java
+++ b/src/main/java/org/qubership/integration/platform/engine/configuration/camel/CamelPubSubConfiguration.java
@@ -1,0 +1,22 @@
+package org.qubership.integration.platform.engine.configuration.camel;
+
+import org.apache.camel.component.google.pubsub.GooglePubsubComponent;
+import org.apache.camel.spi.ComponentCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+public class CamelPubSubConfiguration {
+    @Bean
+    @ConditionalOnProperty(name = "qip.pubsub.emulator.enabled", havingValue = "true")
+    public ComponentCustomizer servletCustomComponentCustomizer(
+            @Value("${qip.pubsub.emulator.address}") String address
+    ) {
+        return ComponentCustomizer.builder(GooglePubsubComponent.class)
+                .build((component) -> {
+                    component.setEndpoint(address);
+                });
+    }
+}

--- a/src/main/resources/META-INF/services/org/apache/camel/component/google-pubsub
+++ b/src/main/resources/META-INF/services/org/apache/camel/component/google-pubsub
@@ -1,0 +1,1 @@
+class=org.qubership.integration.platform.engine.camel.components.pubsub.CustomGooglePubSubComponent

--- a/src/main/resources/application-development.yml
+++ b/src/main/resources/application-development.yml
@@ -36,6 +36,10 @@ logging:
     org.qubership.integration.platform.engine: DEBUG
 
 qip:
+  pubsub:
+    emulator:
+      enabled: true
+      address: pubsub:8085
   local-truststore:
     store:
       path: /app/truststore/defaulttruststore.jks


### PR DESCRIPTION
When a subscription is no longer exist starting a subscriber throws an exception. That causes a continuous creation of a new subscriber and addition it to a subscriber list in a loop. The consumed memory grows until it reaches its limits.

The fix requires changes in the private methods of GooglePubSubConsumer class. So unless this issue is fixed in Apache Camel, we have to have a local copy of CamelGooglePubSub component with the issue fixed.

Here is the link to an issue in Camel Issue Tracker:

https://issues.apache.org/jira/browse/CAMEL-22898

closes #387 