### PR TITLE
fix: [v0.3][#448] Added an override for the custom date in the mapper. The date input format has been changed

### DIFF
--- a/src/main/java/org/qubership/integration/platform/engine/mapper/atlasmap/CustomAtlasContext.java
+++ b/src/main/java/org/qubership/integration/platform/engine/mapper/atlasmap/CustomAtlasContext.java
@@ -28,8 +28,12 @@ import org.qubership.integration.platform.engine.mapper.atlasmap.expressions.Cus
 
 import java.io.InputStream;
 import java.net.URI;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.isNull;
@@ -248,5 +252,14 @@ public class CustomAtlasContext extends DefaultAtlasContext {
             session.head().setSourceField(processed);
             sourceFields.set(i, processed);
         }
+    }
+
+    @Override
+    protected void setDefaultSessionProperties(AtlasSession session) {
+        super.setDefaultSessionProperties(session);
+        Date date = new Date();
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        df.setTimeZone(TimeZone.getDefault());
+        session.getSourceProperties().put("Atlas.CreatedUTCDateTimeWithMillisTZ", df.format(date));
     }
 }

--- a/src/main/java/org/qubership/integration/platform/engine/mapper/atlasmap/TimestampGenerator.java
+++ b/src/main/java/org/qubership/integration/platform/engine/mapper/atlasmap/TimestampGenerator.java
@@ -47,10 +47,10 @@ public class TimestampGenerator implements Function<AtlasSession, String> {
 
     @Override
     public String apply(AtlasSession atlasSession) {
-        String value = (String) atlasSession.getSourceProperties().get("Atlas.CreatedDateTimeTZ");
+        String value = (String) atlasSession.getSourceProperties().get("Atlas.CreatedUTCDateTimeWithMillisTZ");
         return AtlasMapUtils.convertDateFormat(
                 false,
-                "yyyy-MM-dd'T'HH:mm:ssZ",
+                "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
                 Locale.getDefault(Locale.Category.FORMAT).toString(),
                 TimeZone.getDefault().getID(),
                 isUnixEpoch, format, locale, timezone, value);


### PR DESCRIPTION
Close #448 