### PR TITLE
fix: resolve variables for routes in xml preprocessing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.integration.platform</groupId>
     <artifactId>qip-engine</artifactId>
-    <version>0.5.3-ext-service-variable-fix-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <name>QIP Engine</name>
     <description>Engine service orchestrates and runs integration chains, manages their endpoints, records executions,
         collects metrics, and publishes deployment state, using Apache Camel, Consul, and OpenSearch

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.qubership.integration.platform</groupId>
     <artifactId>qip-engine</artifactId>
-    <version>0.5.3-SNAPSHOT</version>
+    <version>0.5.3-ext-service-variable-fix-SNAPSHOT</version>
     <name>QIP Engine</name>
     <description>Engine service orchestrates and runs integration chains, manages their endpoints, records executions,
         collects metrics, and publishes deployment state, using Apache Camel, Consul, and OpenSearch

--- a/src/main/java/org/qubership/integration/platform/engine/service/IntegrationRuntimeService.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/IntegrationRuntimeService.java
@@ -469,6 +469,7 @@ public class IntegrationRuntimeService implements ApplicationContextAware {
         if (maasService.isPresent()) {
             configurationXml = maasService.get().resolveDeploymentMaasParameters(configuration, configurationXml);
         }
+        RegisterRoutesInControlPlaneAction.resolveVariablesInRoutes(variablesService, configuration);
         configurationXml = resolveRouteVariables(configuration.getRoutes(), configurationXml);
         if (xmlPreProcessor.isPresent()) {
             configurationXml = xmlPreProcessor.get().process(configurationXml);

--- a/src/main/java/org/qubership/integration/platform/engine/service/IntegrationRuntimeService.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/IntegrationRuntimeService.java
@@ -469,7 +469,7 @@ public class IntegrationRuntimeService implements ApplicationContextAware {
         if (maasService.isPresent()) {
             configurationXml = maasService.get().resolveDeploymentMaasParameters(configuration, configurationXml);
         }
-        RegisterRoutesInControlPlaneAction.resolveVariablesInRoutes(variablesService, configuration);
+        variablesService.resolveVariablesInRoutes(configuration);
         configurationXml = resolveRouteVariables(configuration.getRoutes(), configurationXml);
         if (xmlPreProcessor.isPresent()) {
             configurationXml = xmlPreProcessor.get().process(configurationXml);

--- a/src/main/java/org/qubership/integration/platform/engine/service/VariablesService.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/VariablesService.java
@@ -29,6 +29,8 @@ import org.qubership.integration.platform.engine.events.CommonVariablesUpdatedEv
 import org.qubership.integration.platform.engine.events.SecuredVariablesUpdatedEvent;
 import org.qubership.integration.platform.engine.kubernetes.KubeOperator;
 import org.qubership.integration.platform.engine.model.constants.CamelConstants;
+import org.qubership.integration.platform.engine.model.deployment.update.DeploymentConfiguration;
+import org.qubership.integration.platform.engine.model.deployment.update.RouteType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -42,6 +44,8 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static java.util.Objects.nonNull;
 
 @Slf4j
 @Component
@@ -212,5 +216,14 @@ public class VariablesService {
 
     public boolean hasVariableReferences(String text) {
         return VARIABLE_PATTERN.matcher(text).find();
+    }
+
+    public void resolveVariablesInRoutes(DeploymentConfiguration deploymentConfiguration) {
+        deploymentConfiguration.getRoutes().stream()
+                .filter(route -> nonNull(route.getVariableName())
+                        && (RouteType.EXTERNAL_SENDER == route.getType()
+                        || RouteType.EXTERNAL_SERVICE == route.getType()))
+                .filter(route -> variablesService.hasVariableReferences(route.getPath()))
+                .forEach(route -> route.setPath(variablesService.injectVariables(route.getPath())));
     }
 }

--- a/src/main/java/org/qubership/integration/platform/engine/service/VariablesService.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/VariablesService.java
@@ -223,7 +223,7 @@ public class VariablesService {
                 .filter(route -> nonNull(route.getVariableName())
                         && (RouteType.EXTERNAL_SENDER == route.getType()
                         || RouteType.EXTERNAL_SERVICE == route.getType()))
-                .filter(route -> variablesService.hasVariableReferences(route.getPath()))
-                .forEach(route -> route.setPath(variablesService.injectVariables(route.getPath())));
+                .filter(route -> hasVariableReferences(route.getPath()))
+                .forEach(route -> route.setPath(injectVariables(route.getPath())));
     }
 }

--- a/src/main/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/before/RegisterRoutesInControlPlaneAction.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/before/RegisterRoutesInControlPlaneAction.java
@@ -67,7 +67,7 @@ public class RegisterRoutesInControlPlaneAction implements DeploymentProcessingA
         DeploymentInfo deploymentInfo,
         DeploymentConfiguration deploymentConfiguration
     ) {
-        resolveVariablesInRoutes(deploymentConfiguration);
+        resolveVariablesInRoutes(variablesService, deploymentConfiguration);
 
         // external triggers routes
         List<DeploymentRouteUpdate> gatewayTriggersRoutes = deploymentConfiguration
@@ -105,7 +105,10 @@ public class RegisterRoutesInControlPlaneAction implements DeploymentProcessingA
         }
     }
 
-    private void resolveVariablesInRoutes(DeploymentConfiguration deploymentConfiguration) {
+    public static void resolveVariablesInRoutes(
+        VariablesService variablesService,
+        DeploymentConfiguration deploymentConfiguration
+    ) {
         deploymentConfiguration.getRoutes().stream()
             .filter(route -> nonNull(route.getVariableName())
                 && (RouteType.EXTERNAL_SENDER == route.getType()

--- a/src/main/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/before/RegisterRoutesInControlPlaneAction.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/deployment/processing/actions/context/before/RegisterRoutesInControlPlaneAction.java
@@ -67,7 +67,7 @@ public class RegisterRoutesInControlPlaneAction implements DeploymentProcessingA
         DeploymentInfo deploymentInfo,
         DeploymentConfiguration deploymentConfiguration
     ) {
-        resolveVariablesInRoutes(variablesService, deploymentConfiguration);
+        variablesService.resolveVariablesInRoutes(deploymentConfiguration);
 
         // external triggers routes
         List<DeploymentRouteUpdate> gatewayTriggersRoutes = deploymentConfiguration
@@ -103,18 +103,6 @@ public class RegisterRoutesInControlPlaneAction implements DeploymentProcessingA
         } catch (ControlPlaneException e) {
             throw new DeploymentRetriableException(e);
         }
-    }
-
-    public static void resolveVariablesInRoutes(
-        VariablesService variablesService,
-        DeploymentConfiguration deploymentConfiguration
-    ) {
-        deploymentConfiguration.getRoutes().stream()
-            .filter(route -> nonNull(route.getVariableName())
-                && (RouteType.EXTERNAL_SENDER == route.getType()
-                || RouteType.EXTERNAL_SERVICE == route.getType()))
-            .filter(route -> variablesService.hasVariableReferences(route.getPath()))
-            .forEach(route -> route.setPath(variablesService.injectVariables(route.getPath())));
     }
 
     public static @NotNull DeploymentRouteUpdate formatServiceRoutes(DeploymentRouteUpdate route) {


### PR DESCRIPTION
### Problem
The XML preprocessing ran `resolveRouteVariables` method before variable placeholders like `#{namespace}` were substituted with real values in path. The control plane was registered after substitution, so the hash in the deployed XML did not match the registered egress route that lead to 404 error for templated URLs, while a hardcoded URL without variables worked well.

### Solution
Substitute variables in route path before `resolveRouteVariables` in XML preprocessing, so the hash matches the route registered with the control plane.